### PR TITLE
Removed io_loop argument from PeriodicCallback

### DIFF
--- a/client.py
+++ b/client.py
@@ -13,7 +13,7 @@ class Client(object):
         self.ioloop = IOLoop.instance()
         self.ws = None
         self.connect()
-	PeriodicCallback(self.keep_alive, 20000, io_loop=self.ioloop).start()
+	PeriodicCallback(self.keep_alive, 20000).start()
         self.ioloop.start()
 
     @gen.coroutine


### PR DESCRIPTION
Removed the io_loop argument from the call to PeriodicCallback which has been removed from tornado since version 5.0.